### PR TITLE
Disabling Expo Analytics

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoApplication.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoApplication.java
@@ -85,18 +85,18 @@ public abstract class ExpoApplication extends MultiDexApplication {
         }
       };
 
-      final CrashlyticsCore core = new CrashlyticsCore
-          .Builder()
-          .listener(listener)
-          .build();
+      // final CrashlyticsCore core = new CrashlyticsCore
+      //     .Builder()
+       //    .listener(listener)
+        //   .build();
 
-      Fabric.with(this, new Crashlytics.Builder().core(core).build());
+      // Fabric.with(this, new Crashlytics.Builder().core(core).build());
 
       try {
         String versionName = Constants.getVersionName(this);
-        Crashlytics.setString("exp_client_version", versionName);
+      //   Crashlytics.setString("exp_client_version", versionName);
         if (Constants.INITIAL_URL != null) {
-          Crashlytics.setString("initial_url", Constants.INITIAL_URL);
+        //   Crashlytics.setString("initial_url", Constants.INITIAL_URL);
         }
       } catch (Throwable e) {
         EXL.e(TAG, e.toString());

--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -483,7 +483,7 @@ public class ExponentManifest {
     if (exponentServerHeader != null) {
       try {
         JSONObject eventProperties = new JSONObject(exponentServerHeader);
-        Amplitude.getInstance().logEvent(Analytics.LOAD_DEVELOPER_MANIFEST, eventProperties);
+        // Amplitude.getInstance().logEvent(Analytics.LOAD_DEVELOPER_MANIFEST, eventProperties);
       } catch (Throwable e) {
         EXL.e(TAG, e);
       }

--- a/android/expoview/src/main/java/host/exp/exponent/analytics/Analytics.java
+++ b/android/expoview/src/main/java/host/exp/exponent/analytics/Analytics.java
@@ -71,7 +71,7 @@ public class Analytics {
       if (sdkVersion != null) {
         eventProperties.put(SDK_VERSION, sdkVersion);
       }
-      Amplitude.getInstance().logEvent(eventType, eventProperties);
+      // Amplitude.getInstance().logEvent(eventType, eventProperties);
     } catch (Exception e) {
       EXL.e(TAG, e.getMessage());
     }
@@ -105,7 +105,7 @@ public class Analytics {
       eventProperties.put("MANIFEST_URL", manifestUrl);
 
       boolean isShell = manifestUrl.equals(Constants.INITIAL_URL);
-      Amplitude.getInstance().logEvent(isShell ? "SHELL_EXPERIENCE_LOADED" : "EXPERIENCE_LOADED", eventProperties);
+      // Amplitude.getInstance().logEvent(isShell ? "SHELL_EXPERIENCE_LOADED" : "EXPERIENCE_LOADED", eventProperties);
     } catch (Exception e) {
       EXL.e(TAG, e.getMessage());
     } finally {

--- a/android/expoview/src/main/java/host/exp/exponent/analytics/EXL.java
+++ b/android/expoview/src/main/java/host/exp/exponent/analytics/EXL.java
@@ -50,7 +50,7 @@ public class EXL {
       eventProperties.put("TAG", tag);
       eventProperties.put("MESSAGE", msg);
       eventProperties.put("STACK_TRACE", stackTrace);
-      Amplitude.getInstance().logEvent("LOG_ERROR", eventProperties);
+      // Amplitude.getInstance().logEvent("LOG_ERROR", eventProperties);
     } catch (Throwable e) {
       Log.e(TAG, e.toString());
     }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ErrorFragment.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ErrorFragment.java
@@ -80,7 +80,7 @@ public class ErrorFragment extends Fragment {
       eventProperties.put(Analytics.USER_ERROR_MESSAGE, userErrorMessage);
       eventProperties.put(Analytics.DEVELOPER_ERROR_MESSAGE, developerErrorMessage);
       eventProperties.put(Analytics.MANIFEST_URL, manifestUrl);
-      Amplitude.getInstance().logEvent(Analytics.ERROR_SCREEN, eventProperties);
+      // Amplitude.getInstance().logEvent(Analytics.ERROR_SCREEN, eventProperties);
     } catch (Exception e) {
       EXL.e(TAG, e.getMessage());
     }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -757,7 +757,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
         );
         kernelReactInstanceManager.onHostResume(ExperienceActivity.this, ExperienceActivity.this);
         addView(mNuxOverlayView);
-        Amplitude.getInstance().logEvent("NUX_EXPERIENCE_OVERLAY_SHOWN");
+        // Amplitude.getInstance().logEvent("NUX_EXPERIENCE_OVERLAY_SHOWN");
       }
     });
   }
@@ -795,7 +795,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
               } catch (JSONException e) {
                 EXL.e(TAG, e.getMessage());
               }
-              Amplitude.getInstance().logEvent("NUX_EXPERIENCE_OVERLAY_DISMISSED", eventProperties);
+              // Amplitude.getInstance().logEvent("NUX_EXPERIENCE_OVERLAY_DISMISSED", eventProperties);
             }
 
             public void onAnimationRepeat(Animation animation) {

--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
@@ -65,7 +65,7 @@ public class HomeActivity extends BaseExperienceActivity {
 
     SoLoader.init(this, false);
 
-    Amplitude.getInstance().logEvent("HOME_APPEARED");
+    // Amplitude.getInstance().logEvent("HOME_APPEARED");
 
     registerForNotifications();
   }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -509,7 +509,7 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
         eventProperties.put(Analytics.USER_ERROR_MESSAGE, errorMessage.userErrorMessage());
         eventProperties.put(Analytics.DEVELOPER_ERROR_MESSAGE, errorMessage.developerErrorMessage());
         eventProperties.put(Analytics.MANIFEST_URL, mManifestUrl);
-        Amplitude.getInstance().logEvent(Analytics.ERROR_RELOADED, eventProperties);
+        // Amplitude.getInstance().logEvent(Analytics.ERROR_RELOADED, eventProperties);
       } catch (Exception e) {
         EXL.e(TAG, e.getMessage());
       }

--- a/android/expoview/src/main/java/host/exp/exponent/network/ExponentHttpClient.java
+++ b/android/expoview/src/main/java/host/exp/exponent/network/ExponentHttpClient.java
@@ -264,7 +264,7 @@ public class ExponentHttpClient {
     try {
       JSONObject eventProperties = new JSONObject();
       eventProperties.put("URI", uri);
-      Amplitude.getInstance().logEvent(event, eventProperties);
+      // Amplitude.getInstance().logEvent(event, eventProperties);
     } catch (JSONException e) {
       EXL.e(TAG, e);
     }

--- a/android/expoview/src/main/java/host/exp/exponent/referrer/InstallReferrerReceiver.java
+++ b/android/expoview/src/main/java/host/exp/exponent/referrer/InstallReferrerReceiver.java
@@ -57,7 +57,7 @@ public class InstallReferrerReceiver extends CampaignTrackingReceiver {
     } catch (JSONException e) {
       EXL.e(TAG, e.getMessage());
     }
-    Amplitude.getInstance().logEvent("INSTALL_REFERRER_RECEIVED", eventProperties);
+    // Amplitude.getInstance().logEvent("INSTALL_REFERRER_RECEIVED", eventProperties);
 
     // Preload manifest + bundle if possible
     try {

--- a/android/expoview/src/main/java/host/exp/expoview/Exponent.java
+++ b/android/expoview/src/main/java/host/exp/expoview/Exponent.java
@@ -171,16 +171,16 @@ public class Exponent {
 
 
     // Amplitude
-    Analytics.resetAmplitudeDatabaseHelper();
+    // Analytics.resetAmplitudeDatabaseHelper();
 
     try {
-      Amplitude.getInstance().initialize(context, ExpoViewBuildConfig.DEBUG ? ExponentKeys.AMPLITUDE_DEV_KEY : ExponentKeys.AMPLITUDE_KEY);
+      // Amplitude.getInstance().initialize(context, ExpoViewBuildConfig.DEBUG ? ExponentKeys.AMPLITUDE_DEV_KEY : ExponentKeys.AMPLITUDE_KEY);
     } catch (RuntimeException e) {
       EXL.testError(e);
     }
 
     if (application != null) {
-      Amplitude.getInstance().enableForegroundTracking(application);
+     // Amplitude.getInstance().enableForegroundTracking(application);
     }
     try {
       JSONObject amplitudeUserProperties = new JSONObject();
@@ -188,7 +188,7 @@ public class Exponent {
       amplitudeUserProperties.put("ABI_VERSIONS", Constants.ABI_VERSIONS);
       amplitudeUserProperties.put("TEMPORARY_ABI_VERSION", Constants.TEMPORARY_ABI_VERSION);
       amplitudeUserProperties.put("IS_DETACHED", Constants.isDetached());
-      Amplitude.getInstance().setUserProperties(amplitudeUserProperties);
+      // Amplitude.getInstance().setUserProperties(amplitudeUserProperties);
     } catch (JSONException e) {
       EXL.e(TAG, e);
     }
@@ -306,7 +306,7 @@ public class Exponent {
   public static void logException(Throwable throwable) {
     if (!ExpoViewBuildConfig.DEBUG) {
       try {
-        Crashlytics.logException(throwable);
+        // Crashlytics.logException(throwable);
       } catch (Throwable e) {
         Log.e(TAG, e.toString());
       }


### PR DESCRIPTION
PR for showing how to disable all stuff for Amplitude and Crashlytics.

Missing AndroidManifest.xml fix:
https://github.com/expo/expo/issues/1764

> First, copy expoview module AndroidManifest.xml to app/src/main directory
Second, './run.sh'
### Build SDK from sources
`cd android`
`./gradlew expoview:assemble` -> Generate new:
`/expo/android/expoview/build/outputs/aar/expoview-prodMinSdk-prodKernel-release.aar`

Replace `/android/maven/host/exp/exponent/expoview/28.0.0/expoview-28.0.0.aar` 
with `expoview-prodMinSdk-prodKernel-release.aar`